### PR TITLE
bedrock: Attempt to resolve SC1008

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -875,8 +875,6 @@ check:
 	#
 	# check against shellcheck
 	#
-	# - SC1008: unrecognized shebang, because shellcheck does not know about
-	#   `#!/bedrock/libexec/busybox sh`
 	# - SC2059: don't use variables in printf format string.  Following
 	#   this recommendation with ANSI color variables did not work for some
 	#   reason.  Excluding the check for the time being.
@@ -887,15 +885,15 @@ check:
 	for file in $$(find src/ -type f); do \
 		if head -n1 "$$file" | grep -q '^#!.*busybox sh$$'; then \
 			echo "checking shell file $$file"; \
-			shellcheck -x -s sh --exclude="SC1008,SC2059,SC2039,SC1090" "$$file" || exit 1; \
+			shellcheck -x -s sh --exclude="SC2059,SC2039,SC1090" "$$file" || exit 1; \
 			! cat "$$file" | shfmt -p -d | grep '.' || exit 1; \
 		elif head -n1 "$$file" | grep -q '^#!.*bash$$'; then \
 			echo "checking bash file $$file"; \
-			shellcheck -x -s bash --exclude="SC1008,SC2059,SC2039,SC1090" "$$file" || exit 1; \
+			shellcheck -x -s bash --exclude="SC2059,SC2039,SC1090" "$$file" || exit 1; \
 			! cat "$$file" | shfmt -ln bash -d | grep '.' || exit 1; \
 		elif head -n1 "$$file" | grep -q -e '^#!.*zsh$$' -e '^#compdef' "$$file"; then \
 			echo "checking zsh file $$file"; \
-			shellcheck -x -s bash --exclude="SC1008,SC2059,SC2039,SC1090" "$$file" || exit 1; \
+			shellcheck -x -s bash --exclude="SC2059,SC2039,SC1090" "$$file" || exit 1; \
 			! cat "$$file" | shfmt -ln bash -d | grep '.' || exit 1; \
 		fi; \
 	done

--- a/src/init/init
+++ b/src/init/init
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # init
 #

--- a/src/slash-bedrock/bin/brl
+++ b/src/slash-bedrock/bin/brl
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl
 #

--- a/src/slash-bedrock/libexec/brl-alias
+++ b/src/slash-bedrock/libexec/brl-alias
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl alias
 #

--- a/src/slash-bedrock/libexec/brl-apply
+++ b/src/slash-bedrock/libexec/brl-apply
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl apply
 #

--- a/src/slash-bedrock/libexec/brl-copy
+++ b/src/slash-bedrock/libexec/brl-copy
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl copy
 #

--- a/src/slash-bedrock/libexec/brl-deref
+++ b/src/slash-bedrock/libexec/brl-deref
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl deref
 #

--- a/src/slash-bedrock/libexec/brl-disable
+++ b/src/slash-bedrock/libexec/brl-disable
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl disable
 #

--- a/src/slash-bedrock/libexec/brl-enable
+++ b/src/slash-bedrock/libexec/brl-enable
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl enable
 #

--- a/src/slash-bedrock/libexec/brl-fetch
+++ b/src/slash-bedrock/libexec/brl-fetch
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl fetch
 #

--- a/src/slash-bedrock/libexec/brl-hide
+++ b/src/slash-bedrock/libexec/brl-hide
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl hide
 #

--- a/src/slash-bedrock/libexec/brl-list
+++ b/src/slash-bedrock/libexec/brl-list
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl list
 #

--- a/src/slash-bedrock/libexec/brl-remove
+++ b/src/slash-bedrock/libexec/brl-remove
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl remove
 #

--- a/src/slash-bedrock/libexec/brl-rename
+++ b/src/slash-bedrock/libexec/brl-rename
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl rename
 #

--- a/src/slash-bedrock/libexec/brl-repair
+++ b/src/slash-bedrock/libexec/brl-repair
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl repair
 #

--- a/src/slash-bedrock/libexec/brl-report
+++ b/src/slash-bedrock/libexec/brl-report
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl report
 #

--- a/src/slash-bedrock/libexec/brl-show
+++ b/src/slash-bedrock/libexec/brl-show
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl show
 #

--- a/src/slash-bedrock/libexec/brl-status
+++ b/src/slash-bedrock/libexec/brl-status
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl status
 #

--- a/src/slash-bedrock/libexec/brl-tutorial
+++ b/src/slash-bedrock/libexec/brl-tutorial
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl tutorial
 #

--- a/src/slash-bedrock/libexec/brl-update
+++ b/src/slash-bedrock/libexec/brl-update
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl update
 #

--- a/src/slash-bedrock/libexec/brl-version
+++ b/src/slash-bedrock/libexec/brl-version
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl version
 #

--- a/src/slash-bedrock/libexec/brl-which
+++ b/src/slash-bedrock/libexec/brl-which
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # brl which
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/.opensuse
+++ b/src/slash-bedrock/share/brl-fetch/distros/.opensuse
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # openSUSE bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/alpine
+++ b/src/slash-bedrock/share/brl-fetch/distros/alpine
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Alpine Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/arch
+++ b/src/slash-bedrock/share/brl-fetch/distros/arch
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Arch Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/arch-32
+++ b/src/slash-bedrock/share/brl-fetch/distros/arch-32
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Arch Linux 32 bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/arch-arm
+++ b/src/slash-bedrock/share/brl-fetch/distros/arch-arm
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Arch Linux ARM bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/artix
+++ b/src/slash-bedrock/share/brl-fetch/distros/artix
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Artix Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/centos
+++ b/src/slash-bedrock/share/brl-fetch/distros/centos
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # CentOS bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/clear
+++ b/src/slash-bedrock/share/brl-fetch/distros/clear
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Clear Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/crux
+++ b/src/slash-bedrock/share/brl-fetch/distros/crux
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # CRUX bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/debian
+++ b/src/slash-bedrock/share/brl-fetch/distros/debian
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Debian bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/devuan
+++ b/src/slash-bedrock/share/brl-fetch/distros/devuan
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Devuan bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Exherbo Linux bootstrap support
 # Copyright 2019 Wulf C. Krueger <philantrop@exherbo.org>

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Exherbo Linux bootstrap support
 # Copyright 2019 Wulf C. Krueger <philantrop@exherbo.org>

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Fedora bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/gentoo
+++ b/src/slash-bedrock/share/brl-fetch/distros/gentoo
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Gentoo Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/kiss
+++ b/src/slash-bedrock/share/brl-fetch/distros/kiss
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # KISS Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/openwrt
+++ b/src/slash-bedrock/share/brl-fetch/distros/openwrt
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # OpenWrt bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/raspbian
+++ b/src/slash-bedrock/share/brl-fetch/distros/raspbian
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Raspbian bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/slackware
+++ b/src/slash-bedrock/share/brl-fetch/distros/slackware
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Slackware bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/solus
+++ b/src/slash-bedrock/share/brl-fetch/distros/solus
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Solus bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/ubuntu
+++ b/src/slash-bedrock/share/brl-fetch/distros/ubuntu
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Ubuntu bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/void
+++ b/src/slash-bedrock/share/brl-fetch/distros/void
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Void Linux bootstrap support
 #

--- a/src/slash-bedrock/share/brl-fetch/distros/void-musl
+++ b/src/slash-bedrock/share/brl-fetch/distros/void-musl
@@ -1,4 +1,5 @@
 #!/bedrock/libexec/busybox sh
+# shellcheck shell=sh
 #
 # Void Linux (musl) bootstrap support
 #


### PR DESCRIPTION
@paradigm Submiting it this way since you blocked me to make PR in your repo

Currently you are setting a directive that ignores SC1008 which will 
skip shell specific checks.

Proposing to use `# shellcheck shell=sh` under the shebang instead

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>